### PR TITLE
Added Devfile Demo

### DIFF
--- a/devfile/deploy_k8s.yaml
+++ b/devfile/deploy_k8s.yaml
@@ -120,19 +120,25 @@ items:
     selector:
       app.kubernetes.io/name: employee-manager
       app.kubernetes.io/component: nodejs-app
-- apiVersion: v1
-  kind: Route
+-
+  apiVersion: extensions/v1beta1
+  kind: Ingress
   metadata:
-    name: nodejs-web-endpoint
+    name: nodejs-ingress
     labels:
       app.kubernetes.io/name: employee-manager
       app.kubernetes.io/component: nodejs-app
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
   spec:
-    to:
-      kind: Service
-      name: web
-    port:
-      targetPort: web
+    rules:
+    - host: nodejs.192.168.99.100.nip.io
+      http:
+        paths:
+        - path: /
+          backend:
+            serviceName: web
+            servicePort: 80
 -
   apiVersion: v1
   kind: PersistentVolumeClaim

--- a/devfile/deploy_k8s.yaml
+++ b/devfile/deploy_k8s.yaml
@@ -91,27 +91,11 @@ items:
           ports:
           - containerPort: 3000
             name: http-server
-          volumeMounts:
-           - mountPath: /projects
-             name: projects
-        volumes:
-          - name: projects
-            persistentVolumeClaim:
-              claimName: projects
--
-  apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: projects
-    labels:
-      app.kubernetes.io/name: employee-manager
-      app.kubernetes.io/component: nodejs-app
-  spec:
-    accessModes:
-     - ReadWriteOnce
-    resources:
-      requests:
-        storage: 1Gi
+          env:
+            - name: MONGO_HOST
+              value: "mongo"
+            - name: MONGO_PORT
+              value: "27017"
 -
   apiVersion: v1
   kind: Service

--- a/devfile/deploy_k8s.yaml
+++ b/devfile/deploy_k8s.yaml
@@ -95,10 +95,13 @@ items:
               value: "mongo"
             - name: MONGO_PORT
               value: "27017"
-          volumes:
+          volumeMounts:
             - name: projects
-              persistentVolumeClaim:
-                claimName: projects
+              mountPath: /projects
+        volumes:
+          - name: projects
+            persistentVolumeClaim:
+              claimName: projects
 -
   apiVersion: v1
   kind: Service

--- a/devfile/deploy_k8s.yaml
+++ b/devfile/deploy_k8s.yaml
@@ -43,7 +43,6 @@ items:
     labels:
       app.kubernetes.io/name: employee-manager
       app.kubernetes.io/component: database
-    name: mongo
   spec:
     ports:
       - port: 27017

--- a/devfile/deploy_k8s.yaml
+++ b/devfile/deploy_k8s.yaml
@@ -6,10 +6,10 @@ items:
   apiVersion: apps/v1
   kind: Deployment
   metadata:
+    name: mongo
     labels:
       app.kubernetes.io/name: employee-manager
       app.kubernetes.io/component: database
-    name: mongo
   spec:
     selector:
       matchLabels:
@@ -23,8 +23,8 @@ items:
         name: mongo
       spec:
         containers:
-        - image: mongo
-          name: mongo
+        - name: mongo
+          image: mongo
           ports:
           - name: mongo
             containerPort: 27017
@@ -68,10 +68,10 @@ items:
   apiVersion: apps/v1
   kind: Deployment
   metadata:
+    name: nodejs-app
     labels:
       app.kubernetes.io/name: employee-manager
       app.kubernetes.io/component: nodejs-app
-    name: nodejs-app
   spec:
     selector:
       matchLabels:
@@ -85,8 +85,8 @@ items:
         name: nodejs-app
       spec:
         containers:
-        - image: "sleshchenko/nodejs-mongo-sample:latest"
-          name: web
+        - name: web-app
+          image: "sleshchenko/nodejs-mongo-sample:latest"
           ports:
           - containerPort: 3000
             name: http-server
@@ -120,35 +120,30 @@ items:
     selector:
       app.kubernetes.io/name: employee-manager
       app.kubernetes.io/component: nodejs-app
--
-  apiVersion: extensions/v1beta1
-  kind: Ingress
+- apiVersion: v1
+  kind: Route
   metadata:
-    name: nodejs-ingress
+    name: nodejs-web-endpoint
     labels:
       app.kubernetes.io/name: employee-manager
       app.kubernetes.io/component: nodejs-app
-    annotations:
-      kubernetes.io/ingress.class: "nginx"
   spec:
-    rules:
-    - host: nodejs.192.168.99.100.nip.io
-      http:
-        paths:
-        - path: /
-          backend:
-            serviceName: web
-            servicePort: 80
-- kind: PersistentVolumeClaim
+    to:
+      kind: Service
+      name: web
+    port:
+      targetPort: web
+-
   apiVersion: v1
+  kind: PersistentVolumeClaim
   metadata:
-    labels:
-      app.kubernetes.io/component: nodejs-app
-      app.kubernetes.io/name: employee-manager
     name: projects
+    labels:
+      app.kubernetes.io/name: employee-manager
+      app.kubernetes.io/component: nodejs-app
   spec:
     accessModes:
-      - ReadWriteOnce
+     - ReadWriteOnce
     resources:
       requests:
         storage: 1Gi

--- a/devfile/deploy_k8s.yaml
+++ b/devfile/deploy_k8s.yaml
@@ -96,6 +96,10 @@ items:
               value: "mongo"
             - name: MONGO_PORT
               value: "27017"
+          volumes:
+            - name: projects
+              persistentVolumeClaim:
+                claimName: projects
 -
   apiVersion: v1
   kind: Service
@@ -133,3 +137,16 @@ items:
           backend:
             serviceName: web
             servicePort: 80
+- kind: PersistentVolumeClaim
+  apiVersion: v1
+  metadata:
+    labels:
+      app.kubernetes.io/component: nodejs-app
+      app.kubernetes.io/name: employee-manager
+    name: projects
+  spec:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi

--- a/devfile/generated.devfile.yaml
+++ b/devfile/generated.devfile.yaml
@@ -1,14 +1,140 @@
 specVersion: 0.0.1
-name: nodejs-sample
+name: chectl-generated
 projects:
+  - name: nodejs-sample-appp
+    source:
+      type: git
+      location: 'https://github.com/sleshchenko/NodeJS-Sample-App.git'
 components:
-  - name: theia-editor
-    type: cheEditor
-    id: org.eclipse.che.editor.theia:next
-  - name: exec-plugin
-    type: chePlugin
-    id: che-machine-exec-plugin:0.0.1
-  - name: node-js
-    type: Kubernetes
-    reference: node-js-sample.yaml
-commands:
+  - type: kubernetes
+    alias: app.kubernetes.io/name=employee-manager
+    referenceContent: |
+      kind: List
+      apiVersion: v1
+      metadata:
+        name: app.kubernetes.io/name=employee-manager
+      items:
+        - apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            labels:
+              app.kubernetes.io/component: database
+              app.kubernetes.io/name: employee-manager
+            name: mongo
+          spec:
+            template:
+              spec:
+                volumes:
+                  - name: mongo-persistent-storage
+                    persistentVolumeClaim:
+                      claimName: mongo-persistent-storage
+                containers:
+                  - name: mongo
+                    image: mongo
+                    ports:
+                      - name: mongo
+                        containerPort: 27017
+                        protocol: TCP
+                    resources: {}
+                    volumeMounts:
+                      - name: mongo-persistent-storage
+                        mountPath: /data/db
+                    terminationMessagePath: /dev/termination-log
+                    terminationMessagePolicy: File
+                    imagePullPolicy: Always
+                restartPolicy: Always
+                terminationGracePeriodSeconds: 30
+                dnsPolicy: ClusterFirst
+                securityContext: {}
+                schedulerName: default-scheduler
+        - apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            labels:
+              app.kubernetes.io/component: nodejs-app
+              app.kubernetes.io/name: employee-manager
+            name: nodejs-app
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: web
+                    image: 'sleshchenko/nodejs-mongo-sample:latest'
+                    ports:
+                      - name: http-server
+                        containerPort: 3000
+                        protocol: TCP
+                    env:
+                      - name: MONGO_HOST
+                        value: mongo
+                      - name: MONGO_PORT
+                        value: '27017'
+                    resources: {}
+                    terminationMessagePath: /dev/termination-log
+                    terminationMessagePolicy: File
+                    imagePullPolicy: Always
+                restartPolicy: Always
+                terminationGracePeriodSeconds: 30
+                dnsPolicy: ClusterFirst
+                securityContext: {}
+                schedulerName: default-scheduler
+        - kind: Service
+          apiVersion: v1
+          metadata:
+            labels:
+              app.kubernetes.io/component: database
+              app.kubernetes.io/name: employee-manager
+            name: mongo
+          spec:
+            type: ClusterIP
+            selector:
+              app.kubernetes.io/component: database
+              app.kubernetes.io/name: employee-manager
+            ports:
+              - port: 27017
+        - kind: Service
+          apiVersion: v1
+          metadata:
+            labels:
+              app.kubernetes.io/component: nodejs-app
+              app.kubernetes.io/name: employee-manager
+            name: web
+          spec:
+            type: LoadBalancer
+            selector:
+              app.kubernetes.io/component: nodejs-app
+              app.kubernetes.io/name: employee-manager
+            ports:
+              - port: 80
+        - kind: Ingress
+          apiVersion: extensions/v1beta1
+          metadata:
+            labels:
+              app.kubernetes.io/component: nodejs-app
+              app.kubernetes.io/name: employee-manager
+            name: nodejs-ingress
+          spec:
+            rules:
+              - host: nodejs.192.168.99.100.nip.io
+                http:
+                  paths:
+                    - path: /
+                      backend:
+                        serviceName: web
+                        servicePort: 80
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            labels:
+              app.kubernetes.io/component: database
+              app.kubernetes.io/name: employee-manager
+            name: mongo-persistent-storage
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+  - type: chePlugin
+    alias: typescript-ls
+    id: 'ms-vscode.typescript:1.30.2'

--- a/devfile/generated.devfile.yaml
+++ b/devfile/generated.devfile.yaml
@@ -1,0 +1,14 @@
+specVersion: 0.0.1
+name: nodejs-sample
+projects:
+components:
+  - name: theia-editor
+    type: cheEditor
+    id: org.eclipse.che.editor.theia:next
+  - name: exec-plugin
+    type: chePlugin
+    id: che-machine-exec-plugin:0.0.1
+  - name: node-js
+    type: Kubernetes
+    reference: node-js-sample.yaml
+commands:

--- a/devfile/generated.devfile.yaml
+++ b/devfile/generated.devfile.yaml
@@ -80,7 +80,7 @@ components:
                     persistentVolumeClaim:
                       claimName: projects
                 containers:
-                  - name: web
+                  - name: web-app
                     image: 'sleshchenko/nodejs-mongo-sample:latest'
                     ports:
                       - name: http-server
@@ -131,22 +131,6 @@ components:
               app.kubernetes.io/name: employee-manager
             ports:
               - port: 80
-        - kind: Ingress
-          apiVersion: extensions/v1beta1
-          metadata:
-            labels:
-              app.kubernetes.io/component: nodejs-app
-              app.kubernetes.io/name: employee-manager
-            name: nodejs-ingress
-          spec:
-            rules:
-              - host: nodejs.192.168.99.100.nip.io
-                http:
-                  paths:
-                    - path: /
-                      backend:
-                        serviceName: web
-                        servicePort: 80
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
@@ -176,4 +160,3 @@ components:
   - type: chePlugin
     alias: typescript-ls
     id: 'ms-vscode.typescript:1.30.2'
-

--- a/devfile/generated.devfile.yaml
+++ b/devfile/generated.devfile.yaml
@@ -159,4 +159,4 @@ components:
                 storage: 1Gi
   - type: chePlugin
     alias: typescript-ls
-    id: 'ms-vscode.typescript:1.30.2'
+    id: 'che-incubator/typescript/1.30.2'

--- a/devfile/generated.devfile.yaml
+++ b/devfile/generated.devfile.yaml
@@ -176,3 +176,4 @@ components:
   - type: chePlugin
     alias: typescript-ls
     id: 'ms-vscode.typescript:1.30.2'
+

--- a/devfile/generated.devfile.yaml
+++ b/devfile/generated.devfile.yaml
@@ -1,10 +1,10 @@
 specVersion: 0.0.1
 name: chectl-generated
 projects:
-  - name: nodejs-sample-appp
-    source:
+  - source:
       type: git
       location: 'https://github.com/sleshchenko/NodeJS-Sample-App.git'
+    name: NodeJS-Sample-App.git
 components:
   - type: kubernetes
     alias: app.kubernetes.io/name=employee-manager
@@ -22,7 +22,16 @@ components:
               app.kubernetes.io/name: employee-manager
             name: mongo
           spec:
+            selector:
+              matchLabels:
+                app.kubernetes.io/component: database
+                app.kubernetes.io/name: employee-manager
             template:
+              metadata:
+                labels:
+                  app.kubernetes.io/component: database
+                  app.kubernetes.io/name: employee-manager
+                name: mongo
               spec:
                 volumes:
                   - name: mongo-persistent-storage
@@ -55,8 +64,21 @@ components:
               app.kubernetes.io/name: employee-manager
             name: nodejs-app
           spec:
+            selector:
+              matchLabels:
+                app.kubernetes.io/component: nodejs-app
+                app.kubernetes.io/name: employee-manager
             template:
+              metadata:
+                labels:
+                  app.kubernetes.io/component: nodejs-app
+                  app.kubernetes.io/name: employee-manager
+                name: nodejs-app
               spec:
+                volumes:
+                  - name: projects
+                    persistentVolumeClaim:
+                      claimName: projects
                 containers:
                   - name: web
                     image: 'sleshchenko/nodejs-mongo-sample:latest'
@@ -70,6 +92,9 @@ components:
                       - name: MONGO_PORT
                         value: '27017'
                     resources: {}
+                    volumeMounts:
+                      - name: projects
+                        mountPath: /projects
                     terminationMessagePath: /dev/termination-log
                     terminationMessagePolicy: File
                     imagePullPolicy: Always
@@ -129,6 +154,19 @@ components:
               app.kubernetes.io/component: database
               app.kubernetes.io/name: employee-manager
             name: mongo-persistent-storage
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            labels:
+              app.kubernetes.io/component: nodejs-app
+              app.kubernetes.io/name: employee-manager
+            name: projects
           spec:
             accessModes:
               - ReadWriteOnce

--- a/devfile/generated.devfile.yaml
+++ b/devfile/generated.devfile.yaml
@@ -144,6 +144,25 @@ components:
             resources:
               requests:
                 storage: 1Gi
+        -
+          apiVersion: extensions/v1beta1
+          kind: Ingress
+          metadata:
+            name: nodejs-ingress
+            labels:
+              app.kubernetes.io/name: employee-manager
+              app.kubernetes.io/component: nodejs-app
+            annotations:
+              kubernetes.io/ingress.class: "nginx"
+          spec:
+            rules:
+            - host: nodejs.192.168.99.100.nip.io
+              http:
+                paths:
+                - path: /
+                  backend:
+                    serviceName: web
+                    servicePort: 80
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:

--- a/devfile/generated.devfile.yaml
+++ b/devfile/generated.devfile.yaml
@@ -131,6 +131,22 @@ components:
               app.kubernetes.io/name: employee-manager
             ports:
               - port: 80
+        - kind: Ingress
+          apiVersion: extensions/v1beta1
+          metadata:
+            labels:
+              app.kubernetes.io/component: nodejs-app
+              app.kubernetes.io/name: employee-manager
+            name: nodejs-ingress
+          spec:
+            rules:
+              - host: nodejs.192.168.99.100.nip.io
+                http:
+                  paths:
+                    - path: /
+                      backend:
+                        serviceName: web
+                        servicePort: 80
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
@@ -144,25 +160,6 @@ components:
             resources:
               requests:
                 storage: 1Gi
-        -
-          apiVersion: extensions/v1beta1
-          kind: Ingress
-          metadata:
-            name: nodejs-ingress
-            labels:
-              app.kubernetes.io/name: employee-manager
-              app.kubernetes.io/component: nodejs-app
-            annotations:
-              kubernetes.io/ingress.class: "nginx"
-          spec:
-            rules:
-            - host: nodejs.192.168.99.100.nip.io
-              http:
-                paths:
-                - path: /
-                  backend:
-                    serviceName: web
-                    servicePort: 80
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
@@ -178,4 +175,5 @@ components:
                 storage: 1Gi
   - type: chePlugin
     alias: typescript-ls
-    id: 'che-incubator/typescript/1.30.2'
+    id: che-incubator/typescript/1.30.2
+

--- a/devfile/node-js-sample.yaml
+++ b/devfile/node-js-sample.yaml
@@ -7,14 +7,20 @@ items:
   kind: Deployment
   metadata:
     labels:
-      name: mongo
-    name: mongo-controller
+      app.kubernetes.io/name: employee-manager
+      app.kubernetes.io/component: database
+    name: mongo
   spec:
+    selector:
+      matchLabels:
+        app.kubernetes.io/name: employee-manager
+        app.kubernetes.io/component: database
     template:
       metadata:
         labels:
-          name: mongo
-        name: mongo-controller
+          app.kubernetes.io/name: employee-manager
+          app.kubernetes.io/component: database
+        name: mongo
       spec:
         containers:
         - image: mongo
@@ -35,46 +41,52 @@ items:
   metadata:
     name: mongo
     labels:
-      name: mongo
+      app.kubernetes.io/name: employee-manager
+      app.kubernetes.io/component: database
     name: mongo
   spec:
     ports:
       - port: 27017
         targetPort: 27017
     selector:
-      name: mongo
+      app.kubernetes.io/name: employee-manager
+      app.kubernetes.io/component: database
 -
   apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     name: mongo-persistent-storage
+    labels:
+      app.kubernetes.io/name: employee-manager
+      app.kubernetes.io/component: database
   spec:
     accessModes:
      - ReadWriteOnce
     resources:
       requests:
-        storage: 3Gi
+        storage: 1Gi
 -
   apiVersion: apps/v1
   kind: Deployment
   metadata:
-    name: web
     labels:
-      app: nodejs
+      app.kubernetes.io/name: employee-manager
+      app.kubernetes.io/component: nodejs-app
+    name: nodejs-app
   spec:
-    replicas: 2
     selector:
-      name: web
+      matchLabels:
+        app.kubernetes.io/name: employee-manager
+        app.kubernetes.io/component: nodejs-app
     template:
       metadata:
         labels:
-          app: nodejs
-        name: web-controller
+          app.kubernetes.io/name: employee-manager
+          app.kubernetes.io/component: nodejs-app
+        name: nodejs-app
       spec:
         containers:
-        - image: node:0.10.40
-          command: ['tail', '-f', '/dev/null']
-          args: []
+        - image: "sleshchenko/nodejs-mongo-sample:latest"
           name: web
           ports:
           - containerPort: 3000
@@ -83,26 +95,31 @@ items:
            - mountPath: /projects
              name: projects
         volumes:
-         - name: projects
-           persistentVolumeClaim:
-             claimName: projects
-- apiVersion: v1
+          - name: projects
+            persistentVolumeClaim:
+              claimName: projects
+-
+  apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
     name: projects
+    labels:
+      app.kubernetes.io/name: employee-manager
+      app.kubernetes.io/component: nodejs-app
   spec:
     accessModes:
      - ReadWriteOnce
     resources:
       requests:
-        storage: 2Gi
+        storage: 1Gi
 -
   apiVersion: v1
   kind: Service
   metadata:
     name: web
     labels:
-      name: web
+      app.kubernetes.io/name: employee-manager
+      app.kubernetes.io/component: nodejs-app
   spec:
     type: LoadBalancer
     ports:
@@ -111,14 +128,24 @@ items:
         targetPort: 3000
         protocol: TCP
     selector:
-      app: nodejs
-- apiVersion: v1
-  kind: Route
+      app.kubernetes.io/name: employee-manager
+      app.kubernetes.io/component: nodejs-app
+-
+  apiVersion: extensions/v1beta1
+  kind: Ingress
   metadata:
-    name: che
+    name: nodejs-ingress
+    labels:
+      app.kubernetes.io/name: employee-manager
+      app.kubernetes.io/component: nodejs-app
+    annotations:
+      kubernetes.io/ingress.class: "nginx"
   spec:
-    to:
-      kind: Service
-      name: web
-    port:
-      targetPort: web
+    rules:
+    - host: nodejs.192.168.99.100.nip.io
+      http:
+        paths:
+        - path: /
+          backend:
+            serviceName: web
+            servicePort: 80

--- a/devfile/node-js-sample.yaml
+++ b/devfile/node-js-sample.yaml
@@ -1,0 +1,124 @@
+---
+apiVersion: v1
+kind: List
+items:
+-
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      name: mongo
+    name: mongo-controller
+  spec:
+    template:
+      metadata:
+        labels:
+          name: mongo
+        name: mongo-controller
+      spec:
+        containers:
+        - image: mongo
+          name: mongo
+          ports:
+          - name: mongo
+            containerPort: 27017
+          volumeMounts:
+              - name: mongo-persistent-storage
+                mountPath: /data/db
+        volumes:
+          - name: mongo-persistent-storage
+            persistentVolumeClaim:
+              claimName: mongo-persistent-storage
+-
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: mongo
+    labels:
+      name: mongo
+    name: mongo
+  spec:
+    ports:
+      - port: 27017
+        targetPort: 27017
+    selector:
+      name: mongo
+-
+  apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: mongo-persistent-storage
+  spec:
+    accessModes:
+     - ReadWriteOnce
+    resources:
+      requests:
+        storage: 3Gi
+-
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: web
+    labels:
+      app: nodejs
+  spec:
+    replicas: 2
+    selector:
+      name: web
+    template:
+      metadata:
+        labels:
+          app: nodejs
+        name: web-controller
+      spec:
+        containers:
+        - image: node:0.10.40
+          command: ['tail', '-f', '/dev/null']
+          args: []
+          name: web
+          ports:
+          - containerPort: 3000
+            name: http-server
+          volumeMounts:
+           - mountPath: /projects
+             name: projects
+        volumes:
+         - name: projects
+           persistentVolumeClaim:
+             claimName: projects
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: projects
+  spec:
+    accessModes:
+     - ReadWriteOnce
+    resources:
+      requests:
+        storage: 2Gi
+-
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: web
+    labels:
+      name: web
+  spec:
+    type: LoadBalancer
+    ports:
+      - name: web
+        port: 80
+        targetPort: 3000
+        protocol: TCP
+    selector:
+      app: nodejs
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: che
+  spec:
+    to:
+      kind: Service
+      name: web
+    port:
+      targetPort: web

--- a/devfile/ready-to-use.devfile.yaml
+++ b/devfile/ready-to-use.devfile.yaml
@@ -80,7 +80,7 @@ components:
                     persistentVolumeClaim:
                       claimName: projects
                 containers:
-                  - name: web
+                  - name: web-app
                     image: 'sleshchenko/nodejs-mongo-sample:latest'
                     command: ['tail']
                     args: ['-f', '/dev/null']
@@ -161,7 +161,7 @@ components:
                 storage: 1Gi
   - type: chePlugin
     alias: typescript-ls
-    id: 'ms-vscode.typescript:1.30.2'
+    id: che-incubator/typescript/1.30.2
 commands:
   - name: run
     actions:

--- a/devfile/ready-to-use.devfile.yaml
+++ b/devfile/ready-to-use.devfile.yaml
@@ -1,10 +1,10 @@
 specVersion: 0.0.1
 name: chectl-generated
 projects:
-  - name: nodejs-sample-appp
-    source:
+  - source:
       type: git
       location: 'https://github.com/sleshchenko/NodeJS-Sample-App.git'
+    name: NodeJS-Sample-App.git
 components:
   - type: kubernetes
     alias: node-js
@@ -22,7 +22,16 @@ components:
               app.kubernetes.io/name: employee-manager
             name: mongo
           spec:
+            selector:
+              matchLabels:
+                app.kubernetes.io/component: database
+                app.kubernetes.io/name: employee-manager
             template:
+              metadata:
+                labels:
+                  app.kubernetes.io/component: database
+                  app.kubernetes.io/name: employee-manager
+                name: mongo
               spec:
                 volumes:
                   - name: mongo-persistent-storage
@@ -39,8 +48,6 @@ components:
                     volumeMounts:
                       - name: mongo-persistent-storage
                         mountPath: /data/db
-                    command: ['tail']
-                    args: ['-f', '/dev/null']
                     terminationMessagePath: /dev/termination-log
                     terminationMessagePolicy: File
                     imagePullPolicy: Always
@@ -57,11 +64,26 @@ components:
               app.kubernetes.io/name: employee-manager
             name: nodejs-app
           spec:
+            selector:
+              matchLabels:
+                app.kubernetes.io/component: nodejs-app
+                app.kubernetes.io/name: employee-manager
             template:
+              metadata:
+                labels:
+                  app.kubernetes.io/component: nodejs-app
+                  app.kubernetes.io/name: employee-manager
+                name: nodejs-app
               spec:
+                volumes:
+                  - name: projects
+                    persistentVolumeClaim:
+                      claimName: projects
                 containers:
                   - name: web
                     image: 'sleshchenko/nodejs-mongo-sample:latest'
+                    command: ['tail']
+                    args: ['-f', '/dev/null']
                     ports:
                       - name: http-server
                         containerPort: 3000
@@ -72,6 +94,9 @@ components:
                       - name: MONGO_PORT
                         value: '27017'
                     resources: {}
+                    volumeMounts:
+                      - name: projects
+                        mountPath: /projects
                     terminationMessagePath: /dev/termination-log
                     terminationMessagePolicy: File
                     imagePullPolicy: Always
@@ -137,6 +162,19 @@ components:
             resources:
               requests:
                 storage: 1Gi
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            labels:
+              app.kubernetes.io/component: nodejs-app
+              app.kubernetes.io/name: employee-manager
+            name: projects
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
   - type: chePlugin
     alias: typescript-ls
     id: 'ms-vscode.typescript:1.30.2'
@@ -145,12 +183,12 @@ commands:
     actions:
       - type: exec
         component: node-js
-        command: cd {PROJECTS_ROOT}/node-js-sample && npm install
+        command: cd ${CHE_PROJECTS_ROOT}/NodeJS-Sample-App.git/EmployeeDB && npm install
   - name: run
     actions:
       - type: exec
         component: node-js
-        command: cd {PROJECTS_ROOT}/node-js-sample && npm install
+        command: cd ${CHE_PROJECTS_ROOT}/NodeJS-Sample-App.git/EmployeeDB && node app.js
   - name: stop
     actions:
       - type: exec

--- a/devfile/ready-to-use.devfile.yaml
+++ b/devfile/ready-to-use.devfile.yaml
@@ -188,4 +188,4 @@ commands:
     actions:
       - type: exec
         component: employee-manager
-        command: ps axf | grep 'node app.js' | grep -v grep | awk '{print "kill -9 " $1}' | sh
+        command: pkill node

--- a/devfile/ready-to-use.devfile.yaml
+++ b/devfile/ready-to-use.devfile.yaml
@@ -133,22 +133,6 @@ components:
               app.kubernetes.io/name: employee-manager
             ports:
               - port: 80
-        - kind: Ingress
-          apiVersion: extensions/v1beta1
-          metadata:
-            labels:
-              app.kubernetes.io/component: nodejs-app
-              app.kubernetes.io/name: employee-manager
-            name: nodejs-ingress
-          spec:
-            rules:
-              - host: nodejs.192.168.99.100.nip.io
-                http:
-                  paths:
-                    - path: /
-                      backend:
-                        serviceName: web
-                        servicePort: 80
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:

--- a/devfile/ready-to-use.devfile.yaml
+++ b/devfile/ready-to-use.devfile.yaml
@@ -7,7 +7,7 @@ projects:
     name: NodeJS-Sample-App.git
 components:
   - type: kubernetes
-    alias: node-js
+    alias: employee-manager
     referenceContent: |
       kind: List
       apiVersion: v1
@@ -182,15 +182,15 @@ commands:
   - name: build
     actions:
       - type: exec
-        component: node-js
+        component: employee-manager
         command: cd ${CHE_PROJECTS_ROOT}/NodeJS-Sample-App.git/EmployeeDB && npm install
   - name: run
     actions:
       - type: exec
-        component: node-js
+        component: employee-manager
         command: cd ${CHE_PROJECTS_ROOT}/NodeJS-Sample-App.git/EmployeeDB && node app.js
   - name: stop
     actions:
       - type: exec
-        component: node-js
-        command: kill -9 $(ps aux | grep nodejs | ...)
+        component: employee-manager
+        command: ps axf | grep 'node app.js' | grep -v grep | awk '{print "kill -9 " $1}' | sh

--- a/devfile/ready-to-use.devfile.yaml
+++ b/devfile/ready-to-use.devfile.yaml
@@ -133,19 +133,6 @@ components:
               app.kubernetes.io/name: employee-manager
             ports:
               - port: 80
-        - kind: PersistentVolumeClaim
-          apiVersion: v1
-          metadata:
-            labels:
-              app.kubernetes.io/component: database
-              app.kubernetes.io/name: employee-manager
-            name: mongo-persistent-storage
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: 1Gi
         -
           apiVersion: extensions/v1beta1
           kind: Ingress
@@ -165,6 +152,19 @@ components:
                   backend:
                     serviceName: web
                     servicePort: 80
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            labels:
+              app.kubernetes.io/component: database
+              app.kubernetes.io/name: employee-manager
+            name: mongo-persistent-storage
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:

--- a/devfile/ready-to-use.devfile.yaml
+++ b/devfile/ready-to-use.devfile.yaml
@@ -146,6 +146,25 @@ components:
             resources:
               requests:
                 storage: 1Gi
+        -
+          apiVersion: extensions/v1beta1
+          kind: Ingress
+          metadata:
+            name: nodejs-ingress
+            labels:
+              app.kubernetes.io/name: employee-manager
+              app.kubernetes.io/component: nodejs-app
+            annotations:
+              kubernetes.io/ingress.class: "nginx"
+          spec:
+            rules:
+            - host: nodejs.192.168.99.100.nip.io
+              http:
+                paths:
+                - path: /
+                  backend:
+                    serviceName: web
+                    servicePort: 80
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:

--- a/devfile/ready-to-use.devfile.yaml
+++ b/devfile/ready-to-use.devfile.yaml
@@ -179,11 +179,6 @@ components:
     alias: typescript-ls
     id: 'ms-vscode.typescript:1.30.2'
 commands:
-  - name: build
-    actions:
-      - type: exec
-        component: employee-manager
-        command: cd ${CHE_PROJECTS_ROOT}/NodeJS-Sample-App.git/EmployeeDB && npm install && npm list
   - name: run
     actions:
       - type: exec

--- a/devfile/ready-to-use.devfile.yaml
+++ b/devfile/ready-to-use.devfile.yaml
@@ -1,0 +1,33 @@
+specVersion: 0.0.1
+name: nodejs-sample
+projects:
+  - name: node-js-sample
+    source:
+      type: git
+      location: https://github.com/heroku/node-js-sample.git
+components:
+  - name: theia-editor
+    type: cheEditor
+    id: org.eclipse.che.editor.theia:next
+  - name: exec-plugin
+    type: chePlugin
+    id: che-machine-exec-plugin:0.0.1
+  - name: node-js
+    type: Kubernetes
+    reference: node-js-sample.yaml
+commands:
+  - name: build
+    actions:
+      - type: exec
+        component: node-js
+        command: cd {PROJECTS_ROOT}/node-js-sample && npm install
+  - name: run
+    actions:
+      - type: exec
+        component: node-js
+        command: cd {PROJECTS_ROOT}/node-js-sample && npm install
+  - name: stop
+    actions:
+      - type: exec
+        component: node-js
+        command: kill -9 $(ps aux | grep nodejs | ...)

--- a/devfile/ready-to-use.devfile.yaml
+++ b/devfile/ready-to-use.devfile.yaml
@@ -183,7 +183,7 @@ commands:
     actions:
       - type: exec
         component: employee-manager
-        command: cd ${CHE_PROJECTS_ROOT}/NodeJS-Sample-App.git/EmployeeDB && npm install
+        command: cd ${CHE_PROJECTS_ROOT}/NodeJS-Sample-App.git/EmployeeDB && npm install && npm list
   - name: run
     actions:
       - type: exec

--- a/devfile/ready-to-use.devfile.yaml
+++ b/devfile/ready-to-use.devfile.yaml
@@ -1,20 +1,145 @@
 specVersion: 0.0.1
-name: nodejs-sample
+name: chectl-generated
 projects:
-  - name: node-js-sample
+  - name: nodejs-sample-appp
     source:
       type: git
-      location: https://github.com/heroku/node-js-sample.git
+      location: 'https://github.com/sleshchenko/NodeJS-Sample-App.git'
 components:
-  - name: theia-editor
-    type: cheEditor
-    id: org.eclipse.che.editor.theia:next
-  - name: exec-plugin
-    type: chePlugin
-    id: che-machine-exec-plugin:0.0.1
-  - name: node-js
-    type: Kubernetes
-    reference: node-js-sample.yaml
+  - type: kubernetes
+    alias: node-js
+    referenceContent: |
+      kind: List
+      apiVersion: v1
+      metadata:
+        name: app.kubernetes.io/name=employee-manager
+      items:
+        - apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            labels:
+              app.kubernetes.io/component: database
+              app.kubernetes.io/name: employee-manager
+            name: mongo
+          spec:
+            template:
+              spec:
+                volumes:
+                  - name: mongo-persistent-storage
+                    persistentVolumeClaim:
+                      claimName: mongo-persistent-storage
+                containers:
+                  - name: mongo
+                    image: mongo
+                    ports:
+                      - name: mongo
+                        containerPort: 27017
+                        protocol: TCP
+                    resources: {}
+                    volumeMounts:
+                      - name: mongo-persistent-storage
+                        mountPath: /data/db
+                    command: ['tail']
+                    args: ['-f', '/dev/null']
+                    terminationMessagePath: /dev/termination-log
+                    terminationMessagePolicy: File
+                    imagePullPolicy: Always
+                restartPolicy: Always
+                terminationGracePeriodSeconds: 30
+                dnsPolicy: ClusterFirst
+                securityContext: {}
+                schedulerName: default-scheduler
+        - apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            labels:
+              app.kubernetes.io/component: nodejs-app
+              app.kubernetes.io/name: employee-manager
+            name: nodejs-app
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: web
+                    image: 'sleshchenko/nodejs-mongo-sample:latest'
+                    ports:
+                      - name: http-server
+                        containerPort: 3000
+                        protocol: TCP
+                    env:
+                      - name: MONGO_HOST
+                        value: mongo
+                      - name: MONGO_PORT
+                        value: '27017'
+                    resources: {}
+                    terminationMessagePath: /dev/termination-log
+                    terminationMessagePolicy: File
+                    imagePullPolicy: Always
+                restartPolicy: Always
+                terminationGracePeriodSeconds: 30
+                dnsPolicy: ClusterFirst
+                securityContext: {}
+                schedulerName: default-scheduler
+        - kind: Service
+          apiVersion: v1
+          metadata:
+            labels:
+              app.kubernetes.io/component: database
+              app.kubernetes.io/name: employee-manager
+            name: mongo
+          spec:
+            type: ClusterIP
+            selector:
+              app.kubernetes.io/component: database
+              app.kubernetes.io/name: employee-manager
+            ports:
+              - port: 27017
+        - kind: Service
+          apiVersion: v1
+          metadata:
+            labels:
+              app.kubernetes.io/component: nodejs-app
+              app.kubernetes.io/name: employee-manager
+            name: web
+          spec:
+            type: LoadBalancer
+            selector:
+              app.kubernetes.io/component: nodejs-app
+              app.kubernetes.io/name: employee-manager
+            ports:
+              - port: 80
+        - kind: Ingress
+          apiVersion: extensions/v1beta1
+          metadata:
+            labels:
+              app.kubernetes.io/component: nodejs-app
+              app.kubernetes.io/name: employee-manager
+            name: nodejs-ingress
+          spec:
+            rules:
+              - host: nodejs.192.168.99.100.nip.io
+                http:
+                  paths:
+                    - path: /
+                      backend:
+                        serviceName: web
+                        servicePort: 80
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            labels:
+              app.kubernetes.io/component: database
+              app.kubernetes.io/name: employee-manager
+            name: mongo-persistent-storage
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
+  - type: chePlugin
+    alias: typescript-ls
+    id: 'ms-vscode.typescript:1.30.2'
 commands:
   - name: build
     actions:

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -93,3 +93,4 @@ that waits for another component, like mongo database. This topic should be inve
 good enough just to manually remove init containers is such case.
 - [ ] There is no way to bound projects sources to application container. https://github.com/eclipse/che/issues/12554 should be implemented to avoid including projects PVC to application deployment
 - [ ] Different arguments for deploying Che with `chectl`, auto pick up `CHE_` env vars
+- [ ] Ingress vs Route

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -12,7 +12,11 @@ TODO
     * `oc apply -f node-js-sample.yaml`
   - Demo that application works fine. On minishift/minikube it should be available at http://nodejs.192.168.99.100.nip.io/
 - Demonstrate Devfile
-  - Use `chectl devfile:generate [flags]` command to generate Devfile
+  - Use `chectl devfile:generate` command to generate Devfile:
+      * devfile:generate --language=typescript \
+            --selector="app.kubernetes.io/name=employee-manager" \
+            --project='{"name":"guestbook", "source": "https://github.com/kubernetes/examples.git"}' \
+            --namespace=nodejs-app generated.devfile.yaml
   - Demonstrate generated [Devfile](generated.devfile.yaml)
 - Customize generated Devfile to be able to start developing
   - Override nodejs container entrypoint not to start an application from the begging
@@ -20,7 +24,7 @@ TODO
 - Develop an application
   - Start a workspace from modified [Devfile](ready-to-use.devfile.yaml)
   - Build and Start an application with tasks
-  - Demonstrate that the application that is run in workspace is working
-  - Make some changes
+  - Demonstrate that the application that is run in workspace is working but bug is there
+  - Fix the bug
   - Restart the application with tasks
-  - Demonstrate that the application is updated with made changes\
+  - Demonstrate that the application is updated and bug is fixed

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -70,6 +70,7 @@ To avoid potential issues, it may be safer to use a known working image (tested 
   - Demonstrate that the application is updated and bug is fixed
 - Share Devfile
   - Add the devfile to NodeJS application sources
+  - Modify the Devfile to reference deploy_k8s.yaml and override entrypoint instead of containing all k8s objects
   - Create a workspace with factory by Github URL http://che-che.192.168.99.100.nip.io/f?url=https://github.com/sleshchenko/NodeJS-Sample-App
 
 ##### TODO
@@ -78,7 +79,7 @@ To avoid potential issues, it may be safer to use a known working image (tested 
 - [ ] Write introduction
 - [ ] Consider moving "Deploy NodeJS" app to set up phase to have more time on demonstrating Che instead of sample application
 - [ ] Theia Next is build on each commit and it's not stable process. For demo it would be better to use some unmodifiable docker image that is referenced in built custom plugin registry
-- [ ] Since chectl is used from branch and there is no corresponding release, it is needed to host used binaries somewhere
+- [x] Since chectl is used from branch and there is no corresponding release, it is needed to host used binaries somewhere
 
 ##### Faced issues
 - [x] Che uses not latest version of Che Theia by default. Fixed by https://github.com/eclipse/che/pull/13235

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -6,16 +6,16 @@ TODO
 ## Script (timing ~15 minutes)
 
 - Deploy Node JS application with Mongo
-  - Demonstrate content of [node-js-sample.yaml](node-js-sample.yaml)
+  - Demonstrate content of [deploy_k8s.yaml](deploy_k8s.yaml)
   - Execute
     * `oc new-project nodejs-app`
-    * `oc apply -f node-js-sample.yaml`
+    * `oc apply -f deploy_k8s.yaml`
   - Demo that application works fine. On minishift/minikube it should be available at http://nodejs.192.168.99.100.nip.io/
 - Demonstrate Devfile
   - Use `chectl devfile:generate` command to generate Devfile:
       * chectl devfile:generate --language=typescript \
             --selector="app.kubernetes.io/name=employee-manager" \
-            --project='{"name":"nodejs-sample-appp", "source": "https://github.com/sleshchenko/NodeJS-Sample-App.git"}' \
+            --project='{"name":"nodejs-sample-appp", "source": {"type":"git", "location":"https://github.com/sleshchenko/NodeJS-Sample-App.git"}}' \
             --namespace=nodejs-app > generated.devfile.yaml
   - Demonstrate generated [Devfile](generated.devfile.yaml)
 - Customize generated Devfile to be able to start developing

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -68,4 +68,6 @@ TODO
   - Execute build task
   - Run application with run task and following Theia instructions to access your application
   - Demonstrate that the application is updated and bug is fixed
-- Add the devfile to NodeJS application sources and create a workspace with factory by Github URL
+- Share Devfile
+  - Add the devfile to NodeJS application sources
+  - Create a workspace with factory by Github URL http://che-che.192.168.99.100.nip.io/f?url=https://github.com/sleshchenko/NodeJS-Sample-App

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -6,17 +6,14 @@
 2. Deploy Che server to local cluster
     - `chectl server:start [-p minishift]`
     - After start, additional configuration:
-      - `CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR=org.eclipse.che.editor.theia:next`
-        - This will need to be modified if https://github.com/eclipse/che/pull/13204 is applied to image used in demo
       - `CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY=IfNotPresent`
-    - Start custom plugin registry from sleshchenko/che-plugin-registry:cached-typescript and configure Che Server to use it
+    - TODO Should be updated to latest changes with v3 plugins format: Start custom plugin registry from `sleshchenko/che-plugin-registry:cached-typescript` and configure Che Server to use it
     *Alternatively:*
     ```bash
       # Set tested Che Server image
       export CHE_IMAGE_REPO=amisevsk/che-server
       export CHE_IMAGE_TAG=dockercon
 
-      export CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR=org.eclipse.che.editor.theia:next
       export CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY=IfNotPresent
 
       # custom plugin registry has cached binaries for typescript plugin

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -111,7 +111,7 @@ sources code repository to make it reusable on any Che installation.
 Demo docker images info:
 - Che Server `sleshchenko/che-server:devfile-demo`;
   Updated: 17.05.19. Built is based onto [7.0.0-beta-5.0-SNAPSHOT](https://github.com/eclipse/che/commit/f02735aa48c34ebe89b54e7f63cf84f85ea8dff3)
-  Note that it should be deployed with configuration that is actual for this version if Che.
+  Note that it should be deployed with configuration that is actual for this version of Che.
 - Che Plugin Registry `sleshchenko/che-plugin-registry/devfile-demo`
   Updated: 17.05.19. Built is based onto [https://github.com/sleshchenko/che-plugin-registry/tree/devfileDemo](https://github.com/sleshchenko/che-plugin-registry/commit/06f74db94efae4a50a8b3d64fd13e11d6c5eadd6)
 - Che Theia `sleshchenko/che-theia:devfile-demo`

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -58,7 +58,7 @@ TODO
     ```
   - Demonstrate generated [Devfile](generated.devfile.yaml)
 - Customize generated Devfile to be able to start developing
-  - Override nodejs container entrypoint not to start an application from the begging
+  - Override nodejs container entrypoint not to start an application from the beginning
   - Configure a commands to build, run and stop an application
   - *Alternatively*, show diff between generated devfile and `ready-to-use.devfile.yml`, explaining differences
 - Fix the bug

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -1,5 +1,18 @@
 # Devfile Demo
 
+## Setup
+1. Create minishift/minikube VM
+    - Demo is tested with minishift VM with 8GB memory allocated
+2. Deploy Che server to local cluster
+    - `chectl server:start [-p minishift]`
+    - After start, additional configuration:
+      - `CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR=org.eclipse.che.editor.theia:next`
+        - This will need to be modified if https://github.com/eclipse/che/pull/13204 is applied to image used in demo
+      - `CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY=IfNotPresent`
+3. Modify `deploy_k8s.yaml` to match VM's IP address in ingress:
+    - `sed -i "s/192.168.99.100/$(minishift ip)/g" ./deploy_k8s.yaml`
+4. Run through demo once or cache all images for a smoother experience
+
 ## Introduction
 TODO
 
@@ -31,7 +44,3 @@ TODO
   - Execute build task
   - Run application with run task and following Theia instructions to access your application
   - Demonstrate that the application is updated and bug is fixed
-
-P.S. Set env var for your Che Server CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR=org.eclipse.che.editor.theia:next
-
-Set for optimization: CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY=IfNotPresent

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -13,8 +13,10 @@ sources code repository to make it reusable on any Che installation.
     - `chectl server:start [-p minishift]`
     - After start, additional configuration:
       - `CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY=IfNotPresent`
-    - Start custom plugin registry from `sleshchenko/che-plugin-registry:cached-typescript` and configure Che Server to use it
+    - Start custom plugin registry from `sleshchenko/che-plugin-registry:devfile-demo` and configure Che Server to use it
     *Alternatively:*
+    Note the particular version of `deploy_che.sh` should be used and it depends on Che Server image that is used.
+    With `sleshchenko/che-server:devfile-demo` the following version should be used https://github.com/eclipse/che/blob/f02735aa48c34ebe89b54e7f63cf84f85ea8dff3/deploy/openshift/deploy_che.sh
     ```bash
       # Set tested Che Server image
       export CHE_IMAGE_REPO=sleshchenko/che-server
@@ -25,19 +27,19 @@ sources code repository to make it reusable on any Che installation.
       # custom plugin registry has cached binaries for typescript plugin
       # and it saves ~1 minute on workspace start
       export PLUGIN_REGISTRY_IMAGE="sleshchenko/che-plugin-registry"
-      export PLUGIN_REGISTRY_IMAGE_TAG="cached-typescript"
+      export PLUGIN_REGISTRY_IMAGE_TAG="devfile-demo"
 
       ./deploy_che.sh --deploy-che-plugin-registry --project=che
     ```
 3. Modify `deploy_k8s.yaml` to match VM's IP address in ingress:
     - `sed -i "s/192.168.99.100/$(minishift ip)/g" ./deploy_k8s.yaml`
-4. Install tested binaries of `chectl` https://drive.google.com/drive/folders/1zz8mNfYl-cPmVUP0SJVd4tf34ePdb9ed?usp=sharing
-5. Deploy NodeJS application using [deploy_k8s.yaml](deploy_k8s.yaml)
+4. Deploy NodeJS application using [deploy_k8s.yaml](deploy_k8s.yaml)
    ```bash
      oc new-project nodejs-app
      oc apply -f deploy_k8s.yaml
    ```
    And then check that application is available on http://nodejs.$(minishift ip).nip.io/
+5. Install tested binaries of `chectl` https://drive.google.com/drive/folders/1zz8mNfYl-cPmVUP0SJVd4tf34ePdb9ed?usp=sharing
 6. Run through demo once or cache all images for a smoother experience
 
 ### Note
@@ -103,4 +105,15 @@ To avoid potential issues, it may be safer to use a known working image (tested 
       args: ["-f", "/dev/null"]
     ```
   - Create a workspace with factory by Github URL http://che-che.192.168.99.100.nip.io/f?url=https://github.com/sleshchenko/NodeJS-Sample-App
-    Note that all changes are already committed and pushed to repository. No need to push it yourself
+    Note that all changes are already committed and pushed to repository. No need to push it yourself.
+    Note that you have to stop previously started workspace, otherwise it will fails to start because of services conflicts
+
+### Additional info
+Demo docker images info:
+- Che Server `sleshchenko/che-server:devfile-demo`;
+  Updated: 17.05.19. Built is based onto [7.0.0-beta-5.0-SNAPSHOT](https://github.com/eclipse/che/commit/f02735aa48c34ebe89b54e7f63cf84f85ea8dff3)
+  Note that it should be deployed with configuration that is actual for this version if Che.
+- Che Plugin Registry `sleshchenko/che-plugin-registry/devfile-demo`
+  Updated: 17.05.19. Built is based onto [https://github.com/sleshchenko/che-plugin-registry/tree/devfileDemo](https://github.com/sleshchenko/che-plugin-registry/commit/06f74db94efae4a50a8b3d64fd13e11d6c5eadd6)
+- Che Theia `sleshchenko/che-theia:devfile-demo`
+  Updated: 17.05.19. Built is a copy of `eclipse/che-theia:next` that was actual during updating

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -1,9 +1,24 @@
 # Devfile Demo
 
 ## Introduction
+TODO
 
-## Steps
+## Script (timing ~15 minutes)
 
-- Create a nodjs mongo workspace using a devfile with 2 docker images components with a Factory
-- Edit devfile to use a Kubernetes component with a yaml reference. Create a new workspace
-- Start workspace from existing Kubernetes deployment
+- Deploy Node JS application with Mongo
+  - Demonstrate content of [node-js-sample.yaml](node-js-sample.yaml)
+  - Execute `kubectl/oc apply node-js-sample.yaml`
+  - Demo that application work fine
+- Demonstrate Devfile
+  - Use `chectl devfile:generate [flags]` command to generate Devfile
+  - Demonstrate generated [Devfile](generated.devfile.yaml)
+- Customize generated Devfile to be able to start developing
+  - Override nodejs container entrypoint not to start an application from the begging
+  - Configure a commands to build,run and stop an application
+- Develop an application
+  - Start a workspace from modified [Devfile](ready-to-use.devfile.yaml)
+  - Build and Start an application with tasks
+  - Demonstrate that the application that is run in workspace is working
+  - Make some changes
+  - Restart the application with tasks
+  - Demonstrate that the application is updated with made changes\

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -31,7 +31,7 @@ sources code repository to make it reusable on any Che installation.
     ```
 3. Modify `deploy_k8s.yaml` to match VM's IP address in ingress:
     - `sed -i "s/192.168.99.100/$(minishift ip)/g" ./deploy_k8s.yaml`
-4. Install tested binaries of `chectl`.
+4. Install tested binaries of `chectl` https://drive.google.com/drive/folders/1zz8mNfYl-cPmVUP0SJVd4tf34ePdb9ed?usp=sharing
 5. Run through demo once or cache all images for a smoother experience
 
 ### Note

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -10,21 +10,21 @@ TODO
   - Execute
     * `oc new-project nodejs-app`
     * `oc apply -f deploy_k8s.yaml`
-  - Demo that application works fine. On minishift/minikube it should be available at http://nodejs.192.168.99.100.nip.io/
+  - Demo that application works fine but there is a bug, it's not possible to remove employee.
+    On minishift/minikube it should be available at http://nodejs.192.168.99.100.nip.io/
 - Demonstrate Devfile
   - Use `chectl devfile:generate` command to generate Devfile:
       * chectl devfile:generate --language=typescript \
-            --selector="app.kubernetes.io/name=employee-manager" \
-            --project='{"name":"nodejs-sample-appp", "source": {"type":"git", "location":"https://github.com/sleshchenko/NodeJS-Sample-App.git"}}' \
-            --namespace=nodejs-app > generated.devfile.yaml
+                                --selector="app.kubernetes.io/name=employee-manager" \
+                                --git-repo=https://github.com/sleshchenko/NodeJS-Sample-App.git
+                                --namespace=nodejs-app > generated.devfile.yaml
   - Demonstrate generated [Devfile](generated.devfile.yaml)
 - Customize generated Devfile to be able to start developing
   - Override nodejs container entrypoint not to start an application from the begging
-  - Configure a commands to build,run and stop an application
-- Develop an application
+  - Configure a commands to build, run and stop an application
+- Fix the bug
   - Start a workspace from modified [Devfile](ready-to-use.devfile.yaml)
-  - Build and Start an application with tasks
-  - Demonstrate that the application that is run in workspace is working but bug is there
-  - Fix the bug
-  - Restart the application with tasks
+  - Find and fix the bug in source code: `_` is missing before `id` in delete method
+  - Execute build task
+  - Run application with run task and following Theia instructions to access your application
   - Demonstrate that the application is updated and bug is fixed

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -32,7 +32,13 @@ sources code repository to make it reusable on any Che installation.
 3. Modify `deploy_k8s.yaml` to match VM's IP address in ingress:
     - `sed -i "s/192.168.99.100/$(minishift ip)/g" ./deploy_k8s.yaml`
 4. Install tested binaries of `chectl` https://drive.google.com/drive/folders/1zz8mNfYl-cPmVUP0SJVd4tf34ePdb9ed?usp=sharing
-5. Run through demo once or cache all images for a smoother experience
+5. Deploy NodeJS application using [deploy_k8s.yaml](deploy_k8s.yaml)
+   ```bash
+     oc new-project nodejs-app
+     oc apply -f deploy_k8s.yaml
+   ```
+   And then check that application is available on http://nodejs.$(minishift ip).nip.io/
+6. Run through demo once or cache all images for a smoother experience
 
 ### Note
 To avoid potential issues, it may be safer to use a known working image (tested with image `sleshchenko/che-server:devfile-demo` available in dockerhub)
@@ -40,13 +46,11 @@ To avoid potential issues, it may be safer to use a known working image (tested 
 
 ## Script (timing ~15 minutes)
 
-- Deploy Node JS application with Mongo
-  - Demonstrate content of [deploy_k8s.yaml](deploy_k8s.yaml)
-  - Execute
-    * `oc new-project nodejs-app`
-    * `oc apply -f deploy_k8s.yaml`
+- Demonstrate NodeJS sample application
+  - Demonstrate that you have NodeJS sample application that uses mongo for storing data https://github.com/sleshchenko/NodeJS-Sample-App
+  - Demonstrate that you have this application deployed on Kubernetes/OpenShift with dashboard (deployments, services, ingresses, PVCs)
   - Demo that application works fine but there is a bug, it's not possible to remove employee.
-    On minishift/minikube it should be available at http://nodejs.$(minishift ip).nip.io/
+    Application should be available at http://nodejs.$(minishift ip).nip.io/
 - Demonstrate Devfile
   - Use `chectl devfile:generate` command to generate Devfile:
     ```bash

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -94,3 +94,4 @@ good enough just to manually remove init containers is such case.
 - [ ] There is no way to bound projects sources to application container. https://github.com/eclipse/che/issues/12554 should be implemented to avoid including projects PVC to application deployment
 - [ ] Different arguments for deploying Che with `chectl`, auto pick up `CHE_` env vars
 - [ ] Ingress vs Route
+- [ ] There is no any output during starting of a workspace using GitHub URL based factory 

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -28,3 +28,7 @@ TODO
   - Execute build task
   - Run application with run task and following Theia instructions to access your application
   - Demonstrate that the application is updated and bug is fixed
+
+P.S. Set env var for your Che Server CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR=org.eclipse.che.editor.theia:next
+
+Set for optimization: CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY=IfNotPresent

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -17,8 +17,8 @@ sources code repository to make it reusable on any Che installation.
     *Alternatively:*
     ```bash
       # Set tested Che Server image
-      export CHE_IMAGE_REPO=amisevsk/che-server
-      export CHE_IMAGE_TAG=dockercon
+      export CHE_IMAGE_REPO=sleshchenko/che-server
+      export CHE_IMAGE_TAG=devfile-demo
 
       export CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY=IfNotPresent
 
@@ -34,9 +34,8 @@ sources code repository to make it reusable on any Che installation.
 4. Run through demo once or cache all images for a smoother experience
 
 ### Note
-To avoid potential issues, it may be safer to use a known working image (tested with image `amisevsk/che-server:dockercon` available in dockerhub)
-- `7.0.0-beta-3.0` has issues parsing the generated devfile
-- Current `beta-4.0` snapshot is working
+To avoid potential issues, it may be safer to use a known working image (tested with image `sleshchenko/che-server:devfile-demo` available in dockerhub)
+- Latest `7.0.0-beta-5.0` is also working
 
 ## Script (timing ~15 minutes)
 
@@ -74,9 +73,10 @@ To avoid potential issues, it may be safer to use a known working image (tested 
 
 ##### TODO
 - [ ] Rework Dockerfile of sample application to use CentOS image to avoid permissions issues on OpenShift
-- [ ] Rebuild newer Che images (Che Server, Plugin Registry)
+- [x] Rebuild newer Che images (Che Server, Plugin Registry)
 - [ ] Write introduction
 - [ ] Consider moving "Deploy NodeJS" app to set up phase to have more time on demonstrating Che instead of sample application
+- [ ] Theia Next is build on each commit and it's not stable process. For demo it would be better to use some unmodifiable docker image that is referenced in built custom plugin registry
 
 ##### Faced issues
 - [x] Che uses not latest version of Che Theia by default. Fixed by https://github.com/eclipse/che/pull/13235
@@ -89,3 +89,4 @@ is workspace there are issues because of anyuid.
 that waits for another component, like mongo database. This topic should be investigated more. Maybe it's
 good enough just to manually remove init containers is such case.
 - [ ] There is no way to bound projects sources to application container. https://github.com/eclipse/che/issues/12554 should be implemented to avoid including projects PVC to application deployment
+- [ ] Different arguments for deploying Che with `chectl`, auto pick up `CHE_` env vars

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -13,10 +13,10 @@ TODO
   - Demo that application works fine. On minishift/minikube it should be available at http://nodejs.192.168.99.100.nip.io/
 - Demonstrate Devfile
   - Use `chectl devfile:generate` command to generate Devfile:
-      * devfile:generate --language=typescript \
+      * chectl devfile:generate --language=typescript \
             --selector="app.kubernetes.io/name=employee-manager" \
-            --project='{"name":"guestbook", "source": "https://github.com/kubernetes/examples.git"}' \
-            --namespace=nodejs-app generated.devfile.yaml
+            --project='{"name":"nodejs-sample-appp", "source": "https://github.com/sleshchenko/NodeJS-Sample-App.git"}' \
+            --namespace=nodejs-app > generated.devfile.yaml
   - Demonstrate generated [Devfile](generated.devfile.yaml)
 - Customize generated Devfile to be able to start developing
   - Override nodejs container entrypoint not to start an application from the begging

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -88,3 +88,4 @@ is workspace there are issues because of anyuid.
 - [ ] Wait for mongo with init container. There is an issue in workspace if application has init containers
 that waits for another component, like mongo database. This topic should be investigated more. Maybe it's
 good enough just to manually remove init containers is such case.
+- [ ] There is no way to bound projects sources to application container. https://github.com/eclipse/che/issues/12554 should be implemented to avoid including projects PVC to application deployment

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -14,10 +14,13 @@ TODO
     On minishift/minikube it should be available at http://nodejs.192.168.99.100.nip.io/
 - Demonstrate Devfile
   - Use `chectl devfile:generate` command to generate Devfile:
-      * chectl devfile:generate --language=typescript \
-                                --selector="app.kubernetes.io/name=employee-manager" \
-                                --git-repo=https://github.com/sleshchenko/NodeJS-Sample-App.git
-                                --namespace=nodejs-app > generated.devfile.yaml
+    ```bash
+    chectl devfile:generate \
+      --language=typescript \
+      --selector='app.kubernetes.io/name=employee-manager' \
+      --git-repo='https://github.com/sleshchenko/NodeJS-Sample-App.git' \
+      --namespace='nodejs-app' > generated.devfile.yaml
+    ```
   - Demonstrate generated [Devfile](generated.devfile.yaml)
 - Customize generated Devfile to be able to start developing
   - Override nodejs container entrypoint not to start an application from the begging

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -14,23 +14,26 @@ sources code repository to make it reusable on any Che installation.
     - After start, additional configuration:
       - `CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY=IfNotPresent`
     - Start custom plugin registry from `sleshchenko/che-plugin-registry:devfile-demo` and configure Che Server to use it
-    *Alternatively:*
-    Note the particular version of `deploy_che.sh` should be used and it depends on Che Server image that is used.
-    With `sleshchenko/che-server:devfile-demo` the following version should be used https://github.com/eclipse/che/blob/f02735aa48c34ebe89b54e7f63cf84f85ea8dff3/deploy/openshift/deploy_che.sh
-    ```bash
-      # Set tested Che Server image
-      export CHE_IMAGE_REPO=sleshchenko/che-server
-      export CHE_IMAGE_TAG=devfile-demo
 
-      export CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY=IfNotPresent
+  *Alternatively:*
+```bash
+  # Set tested Che Server image
+  export CHE_IMAGE_REPO=sleshchenko/che-server
+  export CHE_IMAGE_TAG=devfile-demo
 
-      # custom plugin registry has cached binaries for typescript plugin
-      # and it saves ~1 minute on workspace start
-      export PLUGIN_REGISTRY_IMAGE="sleshchenko/che-plugin-registry"
-      export PLUGIN_REGISTRY_IMAGE_TAG="devfile-demo"
+  export CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY=IfNotPresent
 
-      ./deploy_che.sh --deploy-che-plugin-registry --project=che
-    ```
+  # custom plugin registry has cached binaries for typescript plugin and tagged version for Che Theia
+  # and it saves ~1 minute on workspace start
+  export PLUGIN_REGISTRY_IMAGE="sleshchenko/che-plugin-registry"
+  export PLUGIN_REGISTRY_IMAGE_TAG="devfile-demo"
+
+  # Note the particular version of `deploy_che.sh` should be used
+  # and it depends on Che Server image that is used.
+  # With `sleshchenko/che-server:devfile-demo` the following version should be used
+  # https://github.com/eclipse/che/blob/f02735aa48c34ebe89b54e7f63cf84f85ea8dff3/deploy/openshift/deploy_che.sh
+  ./deploy_che.sh --deploy-che-plugin-registry --project=che
+```
 3. Modify `deploy_k8s.yaml` to match VM's IP address in ingress:
     - `sed -i "s/192.168.99.100/$(minishift ip)/g" ./deploy_k8s.yaml`
 4. Deploy NodeJS application using [deploy_k8s.yaml](deploy_k8s.yaml)
@@ -42,13 +45,9 @@ sources code repository to make it reusable on any Che installation.
 5. Install tested binaries of `chectl` https://drive.google.com/drive/folders/1zz8mNfYl-cPmVUP0SJVd4tf34ePdb9ed?usp=sharing
 6. Run through demo once or cache all images for a smoother experience
 
-### Note
-To avoid potential issues, it may be safer to use a known working image (tested with image `sleshchenko/che-server:devfile-demo` available in dockerhub)
-- Latest `7.0.0-beta-5.0` should be also working
-
 ## Script (timing ~15 minutes)
 
-- Demonstrate NodeJS sample application
+1. Demonstrate NodeJS sample application
   - Demonstrate that you have NodeJS sample application that uses mongo for storing data https://github.com/sleshchenko/NodeJS-Sample-App
   - Demonstrate that you have this application deployed on Kubernetes/OpenShift with dashboard (deployments, services, ingresses, PVCs)
   - Demo that application works fine but there is a bug, it's not possible to remove employee.

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -9,7 +9,7 @@ sources code repository to make it reusable on any Che installation.
 ## Setup
 1. Create minishift/minikube VM
     - Demo is tested with minishift VM with 8GB memory allocated
-2. Deploy Che server to local cluster
+2. Deploy Che Server to local cluster
     - `chectl server:start [-p minishift]`
     - After start, additional configuration:
       - `CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY=IfNotPresent`
@@ -36,7 +36,7 @@ sources code repository to make it reusable on any Che installation.
 
 ### Note
 To avoid potential issues, it may be safer to use a known working image (tested with image `sleshchenko/che-server:devfile-demo` available in dockerhub)
-- Latest `7.0.0-beta-5.0` is also working
+- Latest `7.0.0-beta-5.0` should be also working
 
 ## Script (timing ~15 minutes)
 
@@ -46,7 +46,7 @@ To avoid potential issues, it may be safer to use a known working image (tested 
     * `oc new-project nodejs-app`
     * `oc apply -f deploy_k8s.yaml`
   - Demo that application works fine but there is a bug, it's not possible to remove employee.
-    On minishift/minikube it should be available at http://nodejs.192.168.99.100.nip.io/
+    On minishift/minikube it should be available at http://nodejs.$(minishift ip).nip.io/
 - Demonstrate Devfile
   - Use `chectl devfile:generate` command to generate Devfile:
     ```bash
@@ -58,40 +58,45 @@ To avoid potential issues, it may be safer to use a known working image (tested 
     ```
   - Demonstrate generated [Devfile](generated.devfile.yaml)
 - Customize generated Devfile to be able to start developing
-  - Override nodejs container entrypoint not to start an application from the beginning
+  - Make kubernetes component alias simpler, remove `app.kubernetes.io/name=` and leave only `employee-manager`
+  - Override NodeJS container entrypoint not to start an application from the beginning.
+    The following fields should be added to `web-app` container
+    ```yaml
+      command: ["tail"]
+      args: ["-f", "/dev/null"]
+    ```
   - Configure a commands to build, run and stop an application
+    Add the following section to Devfile
+    ```yaml
+      commands:
+      - name: run
+        actions:
+          - type: exec
+            component: employee-manager
+            command: cd ${CHE_PROJECTS_ROOT}/NodeJS-Sample-App.git/EmployeeDB && node app.js
+      - name: stop
+        actions:
+          - type: exec
+            component: employee-manager
+            command: pkill node
+    ```
   - *Alternatively*, show diff between generated devfile and `ready-to-use.devfile.yml`, explaining differences
 - Fix the bug
   - Start a workspace from modified [Devfile](ready-to-use.devfile.yaml)
     - `chectl workspace:start --devfile=ready-to-use.devfile.yaml`
   - Find and fix the bug in source code: `_` is missing before `id` in delete method
-  - Execute build task
-  - Run application with run task and following Theia instructions to access your application
+  - Run application with run task and follow Theia instructions to access your application
   - Demonstrate that the application is updated and bug is fixed
 - Share Devfile
-  - Add the devfile to NodeJS application sources
+  - Add the Devfile to NodeJS application sources
   - Modify the Devfile to reference deploy_k8s.yaml and override entrypoint instead of containing all k8s objects
+    Replace `referenceContent` kubernetes component with the following fields:
+    ```yaml
+      reference: deploy_k8s.yaml
+      entrypoints:
+      - containerName: web-app
+      command: ["tail"]
+      args: ["-f", "/dev/null"]
+    ```
   - Create a workspace with factory by Github URL http://che-che.192.168.99.100.nip.io/f?url=https://github.com/sleshchenko/NodeJS-Sample-App
-
-##### TODO
-- [ ] Rework Dockerfile of sample application to use CentOS image to avoid permissions issues on OpenShift
-- [x] Rebuild newer Che images (Che Server, Plugin Registry)
-- [ ] Write introduction
-- [ ] Consider moving "Deploy NodeJS" app to set up phase to have more time on demonstrating Che instead of sample application
-- [ ] Theia Next is build on each commit and it's not stable process. For demo it would be better to use some unmodifiable docker image that is referenced in built custom plugin registry
-- [x] Since chectl is used from branch and there is no corresponding release, it is needed to host used binaries somewhere
-
-##### Faced issues
-- [x] Che uses not latest version of Che Theia by default. Fixed by https://github.com/eclipse/che/pull/13235
-- [x] Plugin Registry was broken. Fixed by https://github.com/eclipse/che-plugin-registry/pull/134
-- [ ] Unable to set up entrypoint for application container during generate Devfile phase.
-It's needed to edit generated devfile to make it usable for development. Nice to improve this part.
-- [ ] Permissions on OpenShift. Application works fine on image that was used initially node:12.0-alpine, but
-is workspace there are issues because of anyuid.
-- [ ] Wait for mongo with init container. There is an issue in workspace if application has init containers
-that waits for another component, like mongo database. This topic should be investigated more. Maybe it's
-good enough just to manually remove init containers is such case.
-- [ ] There is no way to bound projects sources to application container. https://github.com/eclipse/che/issues/12554 should be implemented to avoid including projects PVC to application deployment
-- [ ] Different arguments for deploying Che with `chectl`, auto pick up `CHE_` env vars
-- [ ] Ingress vs Route
-- [ ] There is no any output during starting of a workspace using GitHub URL based factory 
+    Note that all changes are already committed and pushed to repository. No need to push it yourself

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -31,7 +31,8 @@ sources code repository to make it reusable on any Che installation.
     ```
 3. Modify `deploy_k8s.yaml` to match VM's IP address in ingress:
     - `sed -i "s/192.168.99.100/$(minishift ip)/g" ./deploy_k8s.yaml`
-4. Run through demo once or cache all images for a smoother experience
+4. Install tested binaries of `chectl`.
+5. Run through demo once or cache all images for a smoother experience
 
 ### Note
 To avoid potential issues, it may be safer to use a known working image (tested with image `sleshchenko/che-server:devfile-demo` available in dockerhub)
@@ -77,6 +78,7 @@ To avoid potential issues, it may be safer to use a known working image (tested 
 - [ ] Write introduction
 - [ ] Consider moving "Deploy NodeJS" app to set up phase to have more time on demonstrating Che instead of sample application
 - [ ] Theia Next is build on each commit and it's not stable process. For demo it would be better to use some unmodifiable docker image that is referenced in built custom plugin registry
+- [ ] Since chectl is used from branch and there is no corresponding release, it is needed to host used binaries somewhere
 
 ##### Faced issues
 - [x] Che uses not latest version of Che Theia by default. Fixed by https://github.com/eclipse/che/pull/13235

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -51,10 +51,10 @@ TODO
   - Use `chectl devfile:generate` command to generate Devfile:
     ```bash
     chectl devfile:generate \
-      --language=typescript \
+      --namespace='nodejs-app' \
       --selector='app.kubernetes.io/name=employee-manager' \
       --git-repo='https://github.com/sleshchenko/NodeJS-Sample-App.git' \
-      --namespace='nodejs-app' > generated.devfile.yaml
+      --language=typescript > generated.devfile.yaml
     ```
   - Demonstrate generated [Devfile](generated.devfile.yaml)
 - Customize generated Devfile to be able to start developing
@@ -68,3 +68,4 @@ TODO
   - Execute build task
   - Run application with run task and following Theia instructions to access your application
   - Demonstrate that the application is updated and bug is fixed
+- Add the devfile to NodeJS application sources and create a workspace with factory by Github URL

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -1,5 +1,11 @@
 # Devfile Demo
 
+## Introduction
+Devfile is a new format for defining a development environment, aka Che Workspace.
+It's a straightforward and declarative format and `chectl` provides easy way to start using it.
+`chectl` is able to generate devfile for live application. Then generated devfile can be put into
+sources code repository to make it reusable on any Che installation.
+
 ## Setup
 1. Create minishift/minikube VM
     - Demo is tested with minishift VM with 8GB memory allocated
@@ -7,7 +13,7 @@
     - `chectl server:start [-p minishift]`
     - After start, additional configuration:
       - `CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY=IfNotPresent`
-    - TODO Should be updated to latest changes with v3 plugins format: Start custom plugin registry from `sleshchenko/che-plugin-registry:cached-typescript` and configure Che Server to use it
+    - Start custom plugin registry from `sleshchenko/che-plugin-registry:cached-typescript` and configure Che Server to use it
     *Alternatively:*
     ```bash
       # Set tested Che Server image
@@ -31,9 +37,6 @@
 To avoid potential issues, it may be safer to use a known working image (tested with image `amisevsk/che-server:dockercon` available in dockerhub)
 - `7.0.0-beta-3.0` has issues parsing the generated devfile
 - Current `beta-4.0` snapshot is working
-
-## Introduction
-TODO
 
 ## Script (timing ~15 minutes)
 
@@ -68,3 +71,20 @@ TODO
 - Share Devfile
   - Add the devfile to NodeJS application sources
   - Create a workspace with factory by Github URL http://che-che.192.168.99.100.nip.io/f?url=https://github.com/sleshchenko/NodeJS-Sample-App
+
+##### TODO
+- [ ] Rework Dockerfile of sample application to use CentOS image to avoid permissions issues on OpenShift
+- [ ] Rebuild newer Che images (Che Server, Plugin Registry)
+- [ ] Write introduction
+- [ ] Consider moving "Deploy NodeJS" app to set up phase to have more time on demonstrating Che instead of sample application
+
+##### Faced issues
+- [x] Che uses not latest version of Che Theia by default. Fixed by https://github.com/eclipse/che/pull/13235
+- [x] Plugin Registry was broken. Fixed by https://github.com/eclipse/che-plugin-registry/pull/134
+- [ ] Unable to set up entrypoint for application container during generate Devfile phase.
+It's needed to edit generated devfile to make it usable for development. Nice to improve this part.
+- [ ] Permissions on OpenShift. Application works fine on image that was used initially node:12.0-alpine, but
+is workspace there are issues because of anyuid.
+- [ ] Wait for mongo with init container. There is an issue in workspace if application has init containers
+that waits for another component, like mongo database. This topic should be investigated more. Maybe it's
+good enough just to manually remove init containers is such case.

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -7,8 +7,10 @@ TODO
 
 - Deploy Node JS application with Mongo
   - Demonstrate content of [node-js-sample.yaml](node-js-sample.yaml)
-  - Execute `kubectl/oc apply node-js-sample.yaml`
-  - Demo that application work fine
+  - Execute
+    * `oc new-project nodejs-app`
+    * `oc apply -f node-js-sample.yaml`
+  - Demo that application works fine. On minishift/minikube it should be available at http://nodejs.192.168.99.100.nip.io/
 - Demonstrate Devfile
   - Use `chectl devfile:generate [flags]` command to generate Devfile
   - Demonstrate generated [Devfile](generated.devfile.yaml)

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -9,6 +9,23 @@
       - `CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR=org.eclipse.che.editor.theia:next`
         - This will need to be modified if https://github.com/eclipse/che/pull/13204 is applied to image used in demo
       - `CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY=IfNotPresent`
+    - Start custom plugin registry from sleshchenko/che-plugin-registry:cached-typescript and configure Che Server to use it
+    *Alternatively:*
+    ```bash
+      # Set tested Che Server image
+      export CHE_IMAGE_REPO=amisevsk/che-server
+      export CHE_IMAGE_TAG=dockercon
+
+      export CHE_WORKSPACE_DEVFILE_DEFAULT__EDITOR=org.eclipse.che.editor.theia:next
+      export CHE_WORKSPACE_SIDECAR_IMAGE__PULL__POLICY=IfNotPresent
+
+      # custom plugin registry has cached binaries for typescript plugin
+      # and it saves ~1 minute on workspace start
+      export PLUGIN_REGISTRY_IMAGE="sleshchenko/che-plugin-registry"
+      export PLUGIN_REGISTRY_IMAGE_TAG="cached-typescript"
+
+      ./deploy_che.sh --deploy-che-plugin-registry --project=che
+    ```
 3. Modify `deploy_k8s.yaml` to match VM's IP address in ingress:
     - `sed -i "s/192.168.99.100/$(minishift ip)/g" ./deploy_k8s.yaml`
 4. Run through demo once or cache all images for a smoother experience

--- a/devfile/script.md
+++ b/devfile/script.md
@@ -13,6 +13,11 @@
     - `sed -i "s/192.168.99.100/$(minishift ip)/g" ./deploy_k8s.yaml`
 4. Run through demo once or cache all images for a smoother experience
 
+### Note
+To avoid potential issues, it may be safer to use a known working image (tested with image `amisevsk/che-server:dockercon` available in dockerhub)
+- `7.0.0-beta-3.0` has issues parsing the generated devfile
+- Current `beta-4.0` snapshot is working
+
 ## Introduction
 TODO
 
@@ -38,8 +43,10 @@ TODO
 - Customize generated Devfile to be able to start developing
   - Override nodejs container entrypoint not to start an application from the begging
   - Configure a commands to build, run and stop an application
+  - *Alternatively*, show diff between generated devfile and `ready-to-use.devfile.yml`, explaining differences
 - Fix the bug
   - Start a workspace from modified [Devfile](ready-to-use.devfile.yaml)
+    - `chectl workspace:start --devfile=ready-to-use.devfile.yaml`
   - Find and fix the bug in source code: `_` is missing before `id` in delete method
   - Execute build task
   - Run application with run task and following Theia instructions to access your application


### PR DESCRIPTION
This is PR that contains Devfile Demo.
It's a demo that shows how to create Devfile for live application with chectl and then how to use it.


#### Faced issues
- [x] Che uses not latest version of Che Theia by default. Fixed by https://github.com/eclipse/che/pull/13235
- [x] Plugin Registry was broken. Fixed by https://github.com/eclipse/che-plugin-registry/pull/134
- [ ] Unable to set up entrypoint for application container during generate Devfile phase.
It's needed to edit generated devfile to make it usable for development. Nice to improve this part.
- [ ] Permissions on OpenShift. Application works fine on image that was used initially node:12.0-alpine, but there are issues(unable to perform some commands in terminal) in workspace because of anyuid.
- [ ] Wait for mongo with init container. There is an issue in workspace if application has init containers
that waits for another component, like mongo database. This topic should be investigated more. Maybe it's good enough just to manually remove init containers is such case.
- [ ] There is no way to bound projects sources to application container. https://github.com/eclipse/che/issues/12554 should be implemented to avoid including projects PVC to application deployment
- [ ] Different arguments for deploying Che with `chectl`, auto pick up `CHE_` env vars. Now `script.md` use `deploy_che.sh` script since it more convenient since it has such feature.
- [ ] This demo is designed to be suitable for Kubernetes and OpenShift. `Ingress` is used to make the application available. But Ingress has an issue since `host` should be hardcoded. So, you have to update host if your K8s/OS installation host is different from `192.168.99.100` and you're not able to deploy two NodeJS application in two different namespaces.
- [x] There is no any output during starting of a workspace using GitHub URL based factory. https://github.com/eclipse/che/pull/13332